### PR TITLE
Run tests in encapsulated transactions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,34 +40,77 @@ def client(app):
 
 @pytest.fixture(scope="session")
 def db_tables(app):
-    """Provide a database session with tables created."""
-    db_.create_all()
-    yield db_
+    """Drop and recreate all tables in the database."""
     db_.drop_all()
+    db_.create_all()
 
 
-@pytest.fixture(scope="function")
-def db(db_tables):
-    """Provide a database session in a transaction rolled back on completion."""
-    db_tables.session.begin_nested()
-    yield db_tables
-    db_tables.session.rollback()
+@pytest.fixture(scope="session")
+def db_fixtures(db_tables):
+    """
+    Provide default preinstalled db fixtures.
 
-
-@pytest.fixture(scope="function")
-def models(db):
-    """Return a fixture with test data for all data models."""
+    These are installed session-wide and shared for performance reasons, but
+    tests may of course create their own encapsulated test data if needed.
+    """
     organization = Organization(name='OrgName')
     team = Team(name='TeamName', organization=organization)
     user = User(first_name='User', last_name='Name', email='user@name.test')
     user.set_password('hunter2')
     project = Project(name='ProjectName')
-    models = {
-        'organization': organization,
-        'team': team,
-        'user': user,
-        'project': project,
+    db_.session.add(organization)
+    db_.session.add(team)
+    db_.session.add(user)
+    db_.session.add(project)
+    db_.session.commit()
+
+
+@pytest.fixture(scope="session")
+def connection():
+    """Establish a distinct db connection to be able to use transactions."""
+    with db_.engine.connect() as connection:
+        yield connection
+
+
+@pytest.fixture(scope="function")
+def session(db_tables, connection):
+    """
+    Provide a database test session.
+
+    Wraps the session in a transaction which is rolled back at the end of the
+    test, undoing any operations committed in the session.
+
+    The session is closed upon completion and the original Flask-SQLAlchemy
+    session is reset on the db object.
+
+    See also:
+    https://docs.sqlalchemy.org/en/latest/orm/session_transaction.html#session-external-transaction
+
+    """
+    # Keep a reference to the original session in order to reset it for
+    # subsequent tests that may not require a DB session.
+    flask_sqlalchemy_session = db_.session
+
+    # Create a new scoped session, bound to an external transaction which can be
+    # rolled back independently of the session state.
+    transaction = connection.begin()
+    db_.session = db_.create_scoped_session(
+        options={'bind': connection, 'binds': {}})
+    yield db_.session
+
+    # Roll back anything that occurred in the test session and reset the db
+    # session to the original flask-sqlalchemy session.
+    db_.session.close()
+    transaction.rollback()
+    db_.session = flask_sqlalchemy_session
+
+
+@pytest.fixture(scope="function")
+def models(db_fixtures, session):
+    """Provide preinstalled db fixtures queried from the current db session."""
+    return {
+        'organization': Organization.query.one(),
+        'team': Team.query.one(),
+        'user': User.query.one(),
+        'project': Project.query.one(),
     }
-    for model in models.values():
-        db.session.add(model)
-    return models

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,9 @@ def client(app):
 @pytest.fixture(scope="session")
 def db_tables(app):
     """Drop and recreate all tables in the database."""
+    # Ensure no sessions are left in an open state, which may happen if tests
+    # not using a db session run before setting up tests that do.
+    db_.session.close()
     db_.drop_all()
     db_.create_all()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def app():
 
 @pytest.fixture(scope="session")
 def client(app):
-    """Provide a Flask test client to be used by almost all test cases."""
+    """Provide a Flask test client for endpoint integration tests."""
     with app.test_client() as client:
         yield client
 

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -18,12 +18,7 @@ from iam.models import (
     OrganizationProject, OrganizationUser, TeamProject, TeamUser, UserProject)
 
 
-def test_commit(db, models):
-    """Test actually committing all models from the models fixture."""
-    db.session.commit()
-
-
-def test_owner_role(db, models):
+def test_owner_role(session, models):
     """Test a users admin access to a project through the organization."""
     # Give user owner role, and assign the project to the organization
     OrganizationUser(organization=models['organization'], user=models['user'],
@@ -35,7 +30,7 @@ def test_owner_role(db, models):
     assert models['user'].claims['prj'][models['project'].id] == 'admin'
 
 
-def test_team_role(db, models):
+def test_team_role(session, models):
     """Test a users access to a project through a team."""
     # Assign the user to the team, and give the team write access to the project
     TeamUser(team=models['team'], user=models['user'], role='member')
@@ -45,7 +40,7 @@ def test_team_role(db, models):
     assert models['user'].claims['prj'][models['project'].id] == 'write'
 
 
-def test_user_role(db, models):
+def test_user_role(session, models):
     """Test a users direct access to a project."""
     # Assign the user to the project with read access
     UserProject(user=models['user'], project=models['project'], role='read')

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -42,8 +42,8 @@ def test_metrics(client, db):
 
 def test_get_admin_unauthorized(client):
     """Test unauthorized access to the admin view."""
-    rv = client.get('/admin/')
-    assert rv.status_code == 401
+    response = client.get('/admin/')
+    assert response.status_code == 401
 
 
 def test_get_admin_authorized(client, app):
@@ -51,9 +51,9 @@ def test_get_admin_authorized(client, app):
     credentials = base64.b64encode(f'{app.config["BASIC_AUTH_USERNAME"]}:'
                                    f'{app.config["BASIC_AUTH_PASSWORD"]}'
                                    .encode()).decode()
-    rv = client.get('/admin/',
+    response = client.get('/admin/',
                     headers={'Authorization': f'Basic {credentials}'})
-    assert rv.status_code == 200
+    assert response.status_code == 200
 
 
 def test_authenticate_failure(app, client, models):

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -34,7 +34,7 @@ def test_healthz(client):
     assert response.status_code == 200
 
 
-def test_metrics(client, db):
+def test_metrics(client):
     """Test the metrics endpoint."""
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -46,13 +46,13 @@ def test_get_admin_unauthorized(client):
     assert response.status_code == 401
 
 
-def test_get_admin_authorized(client, app):
+def test_get_admin_authorized(app, client):
     """Test authorized access to the admin view."""
     credentials = base64.b64encode(f'{app.config["BASIC_AUTH_USERNAME"]}:'
                                    f'{app.config["BASIC_AUTH_PASSWORD"]}'
                                    .encode()).decode()
     response = client.get('/admin/',
-                    headers={'Authorization': f'Basic {credentials}'})
+                          headers={'Authorization': f'Basic {credentials}'})
     assert response.status_code == 200
 
 
@@ -68,7 +68,7 @@ def test_authenticate_failure(app, client, models):
     assert response.status_code == 401
 
 
-def test_authenticate_success(app, client, db, models):
+def test_authenticate_success(app, client, session, models):
     """Test valid local authentication."""
     response = client.post('/authenticate/local', data={
         'email': models['user'].email,

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -21,6 +21,13 @@ from datetime import datetime, timedelta
 from jose import jwt
 
 
+def test_openapi_schema(app, client):
+    """Test OpenAPI schema resource."""
+    response = client.get('/swagger/')
+    assert response.status_code == 200
+    assert len(json.loads(response.data)['paths']) > 0
+
+
 def test_healthz(client):
     """Test the readiness endpoint."""
     response = client.get('/healthz')
@@ -101,10 +108,3 @@ def test_authenticate_success(app, client, db, models):
     response = client.post('/refresh',
                            data={'refresh_token': models['user'].refresh_token})
     assert response.status_code == 401
-
-
-def test_openapi_schema(app, client):
-    """Test OpenAPI schema resource."""
-    response = client.get('/swagger/')
-    assert response.status_code == 200
-    assert len(json.loads(response.data)['paths']) > 0

--- a/tests/unit/test_domain.py
+++ b/tests/unit/test_domain.py
@@ -30,7 +30,7 @@ def test_sign_claims(app, models):
     assert datetime.now() + app.config['REFRESH_TOKEN_VALIDITY'] >= expiry
 
 
-def test_create_firebase_user(db):
+def test_create_firebase_user(session):
     """Test creating a Firebase user."""
     user = create_firebase_user('foo_token', {
         'name': 'Foo Bar',


### PR DESCRIPTION
Building on [this commit](https://github.com/DD-DeCaF/model-warehouse/commit/b0fb2ecc38a392fd4a89009bec657db72fc8b9aa#r30925718), this creates a scoped session, assigns it to the Flask-SQLAlchemy object, and also makes sure to reset the original session to ensure that subsequent tests don't attempt to access an already closed session.