### PR TITLE
refactor: remove user rels on delete

### DIFF
--- a/src/iam/models.py
+++ b/src/iam/models.py
@@ -81,15 +81,26 @@ class User(db.Model):
     last_name = db.Column(db.String(256))
     email = db.Column(db.String(256), unique=True, nullable=False)
 
-    organizations = db.relationship('OrganizationUser', back_populates='user',
-                                    lazy='joined')
-    teams = db.relationship('TeamUser', back_populates='user', lazy='joined')
+    organizations = db.relationship('OrganizationUser',
+                                    back_populates='user',
+                                    lazy='joined',
+                                    cascade='delete, delete-orphan')
+    teams = db.relationship('TeamUser',
+                            back_populates='user',
+                            lazy='joined',
+                            cascade='delete, delete-orphan')
 
-    projects = db.relationship('UserProject', back_populates='user')
+    projects = db.relationship('UserProject',
+                               back_populates='user',
+                               cascade='delete, delete-orphan')
 
-    refresh_tokens = db.relationship('RefreshToken', back_populates='user')
+    refresh_tokens = db.relationship('RefreshToken',
+                                     back_populates='user',
+                                     cascade='delete, delete-orphan')
 
-    consents = db.relationship('Consent', back_populates='user')
+    consents = db.relationship('Consent',
+                               back_populates='user',
+                               cascade='delete, delete-orphan')
 
     def __repr__(self):
         """Return a printable representation."""


### PR DESCRIPTION
Suggestion to automatically remove relationships (UserProject, TeamUser, OrganizationUser) and other entities related only to user (RefreshToken, Consent) when the user is deleted from the database. It would simplify the steps for when in the future somebody would need to delete a user and data related to them.

What do you think?